### PR TITLE
Makefile: Use CC variable instead of explicit gcc

### DIFF
--- a/EVL_WS_14_15/makefile
+++ b/EVL_WS_14_15/makefile
@@ -1,8 +1,9 @@
+CC?="cc"
 all: aufg1 aufg2 aufg3 aufg4 aufg5 aufg6 aufg7 aufg8_1 aufg8_1
 .PHONY: all
 
 %: %.c
-	gcc -o $@ $^
+	$(CC) -o $@ $^
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This allows e.g. `make CC=clang`.
